### PR TITLE
Fix Rails 7.1 deprecation warning

### DIFF
--- a/lib/yabeda/active_record.rb
+++ b/lib/yabeda/active_record.rb
@@ -72,7 +72,7 @@ module Yabeda
       # Connection pool metrics collection
       collect do
         connection_pools = \
-          if ::ActiveRecord.version >= "7.1"
+          if ::ActiveRecord.version >= Gem::Version.new("7.1")
             ::ActiveRecord::Base.connection_handler.connection_pool_list(:all)
           else
             ::ActiveRecord::Base.connection_handler.connection_pool_list

--- a/lib/yabeda/active_record.rb
+++ b/lib/yabeda/active_record.rb
@@ -72,7 +72,7 @@ module Yabeda
       # Connection pool metrics collection
       collect do
         connection_pools = \
-          if Rails.version >= "7.1"
+          if ::ActiveRecord.version >= "7.1"
             ::ActiveRecord::Base.connection_handler.connection_pool_list(:all)
           else
             ::ActiveRecord::Base.connection_handler.connection_pool_list

--- a/lib/yabeda/active_record.rb
+++ b/lib/yabeda/active_record.rb
@@ -71,7 +71,12 @@ module Yabeda
 
       # Connection pool metrics collection
       collect do
-        connection_pools = ::ActiveRecord::Base.connection_handler.connection_pool_list
+        connection_pools = \
+          if Rails.version >= "7.1"
+            ::ActiveRecord::Base.connection_handler.connection_pool_list(:all)
+          else
+            ::ActiveRecord::Base.connection_handler.connection_pool_list
+          end
 
         connection_pools.each do |connection_pool|
           stats = connection_pool.stat


### PR DESCRIPTION
```
DEPRECATION WARNING: `connection_pool_list` currently only applies to connection pools in the current role (`writing`). In Rails 7.2, this method will apply to all known pools, regardless of role. To affect only those connections belonging to a specific role, pass the role name as an argument. To switch to the new behavior, pass `:all` as the role name. (called from block (2 levels) in <module:ActiveRecord> at /Users/jacopobeschi/.rbenv/versions/3.3.0-preview2/lib/ruby/gems/3.3.0+0/gems/yabeda-activerecord-0.1.0/lib/yabeda/active_record.rb:74)
```

See https://github.com/rails/rails/blob/7-1-stable/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb#L294-L300